### PR TITLE
Closes #1: Allow providing parameters dynamically at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.*
+!.gitignore
+!.gitkeep
 /target/

--- a/src/main/java/org/madgik/MVTopicModel/PTMFlow.java
+++ b/src/main/java/org/madgik/MVTopicModel/PTMFlow.java
@@ -82,6 +82,10 @@ public class PTMFlow {
     String SQLConnectionString = "jdbc:postgresql://localhost:5432/tender?user=postgres&password=postgres&ssl=false"; //"jdbc:sqlite:C:/projects/OpenAIRE/fundedarxiv.db";
 
     public PTMFlow() throws IOException {
+        this(null);
+    }
+    
+    public PTMFlow(Map<String,String> runtimeProp) throws IOException {
 
         SimilarityType similarityType = SimilarityType.cos; //Cosine 1 jensenShannonDivergence 2 symmetric KLP
 
@@ -93,9 +97,9 @@ public class PTMFlow {
         String dictDir = "";
 
         Connection connection = null;
-
-        getPropValues();
-
+        
+        getPropValues(runtimeProp);    
+        
         if (findKeyPhrases) {
             FindKeyPhrasesPerTopic(SQLConnectionString, experimentId, "openNLP");
         }
@@ -249,7 +253,7 @@ public class PTMFlow {
 
     }
 
-    public void getPropValues() throws IOException {
+    public void getPropValues(Map<String,String> runtimeProp) throws IOException {
 
         InputStream inputStream = null;
         try {
@@ -264,6 +268,10 @@ public class PTMFlow {
                 throw new FileNotFoundException("property file '" + propFileName + "' not found in the classpath");
             }
 
+            if (runtimeProp != null) {
+                prop.putAll(runtimeProp);
+            }
+            
             // get the property value and print it out
             numTopics = Integer.parseInt(prop.getProperty("TopicsNumber"));
             topWords = Integer.parseInt(prop.getProperty("TopWords"));

--- a/src/main/java/org/madgik/dbpediaspotlightclient/DBpediaAnnotator.java
+++ b/src/main/java/org/madgik/dbpediaspotlightclient/DBpediaAnnotator.java
@@ -16,6 +16,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -51,7 +52,7 @@ public class DBpediaAnnotator {
 
     }
 
-      public void getPropValues() throws IOException {
+      public void getPropValues(Map<String,String> runtimeProp) throws IOException {
 
         InputStream inputStream = null;
         try {
@@ -65,7 +66,10 @@ public class DBpediaAnnotator {
             } else {
                 throw new FileNotFoundException("property file '" + propFileName + "' not found in the classpath");
             }
-
+            
+            if (runtimeProp != null) {
+                prop.putAll(runtimeProp);
+            }
            
             SQLConnectionString = prop.getProperty("SQLConnectionString");
             spotlightService = prop.getProperty("SpotlightService");
@@ -325,7 +329,7 @@ public class DBpediaAnnotator {
         Class.forName("org.postgresql.Driver");
         DBpediaAnnotator c = new DBpediaAnnotator();
         logger.info("DBPedia annotation started");
-        c.getPropValues();
+        c.getPropValues(null);
         logger.info("DBPedia annotation: Annotate new publications");
         c.annotatePubs(ExperimentType.OpenAIRE, AnnotatorType.spotlight);
         logger.info("DBPedia annotation: Get extra fields from DBPedia");


### PR DESCRIPTION
This change introduces support for providing properties as runtime parameters for both:
* annotate
* topic modeling

phases. Each property defined in a `Map` overwrites the one defined in `config.properties` file.

This way it will be possible to introduce RESTful service and propagate parameters provided by client.